### PR TITLE
feat: add week numbers column to month view grid

### DIFF
--- a/components/calendar/calendar-month-view.tsx
+++ b/components/calendar/calendar-month-view.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, useCallback, type DragEvent } from "react";
 import { useTranslations, useFormatter } from "next-intl";
 import {
   startOfMonth, endOfMonth, startOfWeek, endOfWeek,
-  eachDayOfInterval, isSameDay, isSameMonth, isToday, format, parseISO,
+  eachDayOfInterval, isSameDay, isSameMonth, isToday, format, parseISO, getWeek,
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { EventCard } from "./event-card";
@@ -34,6 +34,7 @@ export function CalendarMonthView({
   const t = useTranslations("calendar");
   const intlFormatter = useFormatter();
   const weekStart = (firstDayOfWeek === 0 ? 0 : 1) as 0 | 1;
+  const firstWeekContainsDate = weekStart === 1 ? 4 : 1;
 
   const days = useMemo(() => {
     const monthStart = startOfMonth(selectedDate);
@@ -123,9 +124,13 @@ export function CalendarMonthView({
 
   return (
     <div className="flex flex-col flex-1 overflow-hidden" role="grid" aria-label={intlFormatter.dateTime(selectedDate, { month: "long", year: "numeric" })}>
-      <div className="grid grid-cols-7 border-b border-border" role="row">
+      <div className="grid grid-cols-[2.25rem_repeat(7,minmax(0,1fr))] border-b border-border" role="row">
         {dayHeaders.map((d) => (
-          <div key={d} role="columnheader" className="text-center text-xs font-medium text-muted-foreground py-2 border-r border-border last:border-r-0">
+          <div
+            key={d}
+            role="columnheader"
+            className="text-center text-xs font-medium text-muted-foreground py-2 border-r border-border last:border-r-0 first:col-start-2"
+          >
             {t(`days.${d}`)}
           </div>
         ))}
@@ -133,7 +138,12 @@ export function CalendarMonthView({
 
       <div className="flex-1 flex flex-col overflow-y-auto">
         {weeks.map((week, wi) => (
-          <div key={wi} className="grid grid-cols-7 flex-1 min-h-[100px] border-b border-border last:border-b-0" role="row">
+          <div key={wi} className="grid grid-cols-[2.25rem_repeat(7,minmax(0,1fr))] flex-1 min-h-[100px] border-b border-border last:border-b-0" role="row">
+            <div className="border-r border-border bg-muted/30 px-1 py-1 flex items-start justify-center">
+              <span className="text-[10px] text-muted-foreground font-medium leading-5">
+                {getWeek(week[0], { weekStartsOn: weekStart, firstWeekContainsDate })}
+              </span>
+            </div>
             {week.map((day) => {
               const inMonth = isSameMonth(day, selectedDate);
               const selected = isSameDay(day, selectedDate);


### PR DESCRIPTION
  ## What

  This PR adds week numbers to the month view grid.

  - Introduces a dedicated week-number column on the left side of each month-view row.
  - Keeps day columns aligned by using an 8-column grid layout.
  - Avoids rendering a separate empty header cell; day headers start at column 2.

  ## Why

  Users need week numbers in month view for planning and reference.
  At the same time, the top-left “empty corner cell” looked visually unnecessary. This approach preserves clean alignment without adding that explicit blank header cell.

  ## How

  - Updated CalendarMonthView grid from 7 columns to:
    grid-cols-[2.25rem_repeat(7,minmax(0,1fr))]
  - Header row:
      - Day headers now start at column 2 (first:col-start-2), leaving reserved width for the week-number column without rendering a dedicated empty header node.
  - Week rows:
      - Added left week-number cell per row.
      - Week number computed with getWeek(week[0], { weekStartsOn, firstWeekContainsDate })
      - firstWeekContainsDate is set based on locale week start (4 for Monday/ISO-style, 1 for Sunday-style).



<img width="1789" height="875" alt="Screenshot 2026-03-16 at 16 35 48" src="https://github.com/user-attachments/assets/7c886147-bbaa-4078-8c4c-951c9087b14c" />