### PR TITLE
fix: improve action buttons on contact empty state

### DIFF
--- a/components/contacts/contact-list.tsx
+++ b/components/contacts/contact-list.tsx
@@ -170,12 +170,12 @@ export function ContactList({
                 <p className="text-sm font-medium text-foreground">{t("empty_state_title")}</p>
                 <p className="text-xs text-muted-foreground mt-1">{t("empty_state_subtitle")}</p>
                 <div className="flex gap-2 mt-4">
-                  <Button size="sm" onClick={onCreateNew}>
+                  <Button size="sm" onClick={onCreateNew} className="whitespace-nowrap overflow-hidden text-ellipsis">
                     <UserPlus className="w-4 h-4 mr-1.5" />
                     {t("create_new")}
                   </Button>
                   {onImport && (
-                    <Button variant="outline" size="sm" onClick={onImport}>
+                    <Button variant="outline" size="sm" onClick={onImport} className="whitespace-nowrap overflow-hidden text-ellipsis">
                       <Upload className="w-4 h-4 mr-1.5" />
                       {t("import_vcard")}
                     </Button>


### PR DESCRIPTION
Fixed inconsistent button styling on the contact empty state. The text was wrapping, so I applied `whitespace-nowrap`, `overflow-hidden`, and `text-ellipsis` to ensure the buttons remain uniform.

Before:

<img width="409" height="609" alt="Screenshot 2026-03-27 at 10 17 54 AM" src="https://github.com/user-attachments/assets/75f1b576-962e-4419-b8de-bc71a4ab8efd" />

After:

<img width="398" height="588" alt="Screenshot 2026-03-27 at 10 23 49 AM" src="https://github.com/user-attachments/assets/0718a0ed-708a-4b08-893a-7609ef069d63" />

