### PR TITLE
Publish major version container image tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=sha,prefix=
 
       - name: Build and push


### PR DESCRIPTION
This commit adds a `{{major}}` (semantic) version tag `jmap-webmail:1` for published container images.

A major tag helps user stay on a recent version, without manually bumping their targeted image tag. This would be useful, for example now that `jmap-webmail:1.4` has been (or is about to be; see #54) released.

Assuming that semantic versioning is adhered to, staying indefinitely on `jmap-webmail:1` should pose no breaking issues for users, until they decide to move to the next major version.

See

- https://github.com/root-fr/jmap-webmail/pkgs/container/jmap-webmail
- https://github.com/root-fr/jmap-webmail/pkgs/container/jmap-webmail/748466473?tag=1.3
- https://github.com/root-fr/jmap-webmail/pkgs/container/jmap-webmail/748466473?tag=1.3.3
- https://github.com/root-fr/jmap-webmail/issues/54
- https://semver.org/