### PR TITLE
Fix full-day events spanning an extra day in the UI

### DIFF
--- a/components/calendar/calendar-agenda-view.tsx
+++ b/components/calendar/calendar-agenda-view.tsx
@@ -6,7 +6,7 @@ import { format, parseISO, isToday, isTomorrow } from "date-fns";
 import { Calendar as CalendarIcon, MapPin, Users } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { parseDuration, getEventColor } from "./event-card";
-import { getEventEndDate } from "@/lib/calendar-utils";
+import { getEventLastVisibleDate } from "@/lib/calendar-utils";
 import { getParticipantCount } from "@/lib/calendar-participants";
 import type { CalendarEvent, Calendar } from "@/lib/jmap/types";
 
@@ -50,7 +50,7 @@ export function CalendarAgendaView({
     sorted.forEach((ev) => {
       try {
         const start = new Date(ev.start);
-        const end = getEventEndDate(ev);
+        const end = getEventLastVisibleDate(ev);
         const startKey = format(start, "yyyy-MM-dd");
         const endKey = format(end, "yyyy-MM-dd");
 

--- a/components/calendar/calendar-day-view.tsx
+++ b/components/calendar/calendar-day-view.tsx
@@ -6,7 +6,7 @@ import { format, isToday, parseISO } from "date-fns";
 import { cn } from "@/lib/utils";
 import { EventCard, parseDuration } from "./event-card";
 import { QuickEventInput } from "./quick-event-input";
-import { getEventEndDate, layoutOverlappingEvents, formatSnapTime } from "@/lib/calendar-utils";
+import { getEventLastVisibleDate, layoutOverlappingEvents, formatSnapTime } from "@/lib/calendar-utils";
 import type { CalendarEvent, Calendar } from "@/lib/jmap/types";
 import { useTimeGridInteractions } from "@/hooks/use-time-grid-interactions";
 
@@ -47,7 +47,7 @@ export function CalendarDayView({
     events.forEach((ev) => {
       try {
         const start = new Date(ev.start);
-        const end = getEventEndDate(ev);
+        const end = getEventLastVisibleDate(ev);
         const startDay = new Date(start); startDay.setHours(0, 0, 0, 0);
         const endDay = new Date(end); endDay.setHours(0, 0, 0, 0);
         const selDay = new Date(selectedDate); selDay.setHours(0, 0, 0, 0);

--- a/components/calendar/calendar-month-view.tsx
+++ b/components/calendar/calendar-month-view.tsx
@@ -8,7 +8,7 @@ import {
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { EventCard } from "./event-card";
-import { getEventEndDate } from "@/lib/calendar-utils";
+import { getEventEndDate, getEventLastVisibleDate } from "@/lib/calendar-utils";
 import type { CalendarEvent, Calendar } from "@/lib/jmap/types";
 import { useAuthStore } from "@/stores/auth-store";
 import { useCalendarStore } from "@/stores/calendar-store";
@@ -57,7 +57,7 @@ export function CalendarMonthView({
     events.forEach((e) => {
       try {
         const start = new Date(e.start);
-        const end = getEventEndDate(e);
+        const end = getEventLastVisibleDate(e);
         const startDay = new Date(start);
         startDay.setHours(0, 0, 0, 0);
         const endDay = new Date(end);

--- a/components/calendar/calendar-week-view.tsx
+++ b/components/calendar/calendar-week-view.tsx
@@ -8,7 +8,7 @@ import {
 import { cn } from "@/lib/utils";
 import { EventCard, parseDuration } from "./event-card";
 import { QuickEventInput } from "./quick-event-input";
-import { getEventEndDate, layoutOverlappingEvents, formatSnapTime } from "@/lib/calendar-utils";
+import { getEventLastVisibleDate, layoutOverlappingEvents, formatSnapTime } from "@/lib/calendar-utils";
 import type { CalendarEvent, Calendar } from "@/lib/jmap/types";
 import { useTimeGridInteractions } from "@/hooks/use-time-grid-interactions";
 
@@ -59,7 +59,7 @@ export function CalendarWeekView({
     events.forEach((ev) => {
       try {
         const start = new Date(ev.start);
-        const end = getEventEndDate(ev);
+        const end = getEventLastVisibleDate(ev);
         const startDay = new Date(start); startDay.setHours(0, 0, 0, 0);
         const endDay = new Date(end); endDay.setHours(0, 0, 0, 0);
 

--- a/components/calendar/event-modal.tsx
+++ b/components/calendar/event-modal.tsx
@@ -9,6 +9,7 @@ import { X, Trash2, Check, Users, CalendarDays, Copy } from "lucide-react";
 import { format, parseISO, addHours, addDays } from "date-fns";
 import type { CalendarEvent, Calendar, CalendarParticipant } from "@/lib/jmap/types";
 import { parseDuration } from "./event-card";
+import { getEventLastVisibleDate } from "@/lib/calendar-utils";
 import { ParticipantInput } from "./participant-input";
 import { useConfirmDialog } from "@/hooks/use-confirm-dialog";
 import {
@@ -134,6 +135,7 @@ export function EventModal({
 
   const getInitialEnd = (): Date => {
     if (event?.start) {
+      if (event.showWithoutTime) return getEventLastVisibleDate(event);
       const s = parseISO(event.start);
       const dur = parseDuration(event.duration);
       return new Date(s.getTime() + dur * 60000);

--- a/lib/__tests__/calendar-utils.test.ts
+++ b/lib/__tests__/calendar-utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { format } from 'date-fns';
+import { getEventEndDate, getEventLastVisibleDate } from '../calendar-utils';
+import type { CalendarEvent } from '@/lib/jmap/types';
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    start: '2026-05-12T00:00:00',
+    duration: 'P1D',
+    showWithoutTime: true,
+    ...overrides,
+  } as CalendarEvent;
+}
+
+describe('getEventLastVisibleDate', () => {
+  it('keeps a one-day all-day event on its start date', () => {
+    const event = makeEvent();
+
+    expect(format(getEventEndDate(event), "yyyy-MM-dd'T'HH:mm:ss")).toBe('2026-05-13T00:00:00');
+    expect(format(getEventLastVisibleDate(event), 'yyyy-MM-dd')).toBe('2026-05-12');
+  });
+
+  it('keeps a two-day all-day event on the second day but not the third', () => {
+    const event = makeEvent({ duration: 'P2D' });
+
+    expect(format(getEventEndDate(event), "yyyy-MM-dd'T'HH:mm:ss")).toBe('2026-05-14T00:00:00');
+    expect(format(getEventLastVisibleDate(event), 'yyyy-MM-dd')).toBe('2026-05-13');
+  });
+
+  it('does not place a timed event on a day where it ends at midnight', () => {
+    const event = makeEvent({
+      start: '2026-05-12T23:00:00',
+      duration: 'PT1H',
+      showWithoutTime: false,
+    });
+
+    expect(format(getEventEndDate(event), "yyyy-MM-dd'T'HH:mm:ss")).toBe('2026-05-13T00:00:00');
+    expect(format(getEventLastVisibleDate(event), 'yyyy-MM-dd')).toBe('2026-05-12');
+  });
+
+  it('uses the start date for zero-duration events', () => {
+    const event = makeEvent({ duration: 'PT0M', showWithoutTime: false });
+
+    expect(format(getEventLastVisibleDate(event), "yyyy-MM-dd'T'HH:mm:ss")).toBe('2026-05-12T00:00:00');
+  });
+});

--- a/lib/calendar-utils.ts
+++ b/lib/calendar-utils.ts
@@ -8,6 +8,13 @@ export function getEventEndDate(event: CalendarEvent): Date {
   return new Date(start.getTime() + parseDuration(event.duration) * 60000);
 }
 
+export function getEventLastVisibleDate(event: CalendarEvent): Date {
+  const start = new Date(event.start);
+  const end = getEventEndDate(event);
+  if (end.getTime() <= start.getTime()) return start;
+  return new Date(end.getTime() - 1);
+}
+
 export function layoutOverlappingEvents(
   events: CalendarEvent[],
 ): { event: CalendarEvent; column: number; totalColumns: number }[] {


### PR DESCRIPTION
Thanks for the nice project!

I noticed that full-day events are incorrectly spanning an extra day in the UI, and it seems like the end range should simply be exclusive for the UI to render those correctly. So a simple fix could be to subtract a millisecond from the end date, when rendering an event on the UI.

What do you think?

------

I have noticed two other issues when trying this project out on my calendar setup (until now I only used CalDAV):

1. Recurring events created in the past don't show up on the UI (so we seemingly need to fetch more data, and expand those recurring events ourselves, including potentially handling correctly overrides for individual occurrences).
2. Shared calendars & contacts are not shown (need to fetch all principals, to see items not owned by my own account).

I made a vibe-coded solution for both, just in the spirit of experimentation, but they are noticeably bigger changes than this one, and I would definitely need a second pair of eyes there if we were to proceed. But before we do anything about it, what's your stance on this, would you like to see a PR for each and help clean it up, or do you prefer to avoid looking at LLM code? There's absolutely no pressure, I'm happy to share instead some info to help reproduce the issue, and also to test any solution on my data.