### PR TITLE
fix: resizable message list, light-mode contrast, and related layout fixes

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef, useMemo } from "react";
+import { useEffect, useState, useRef, useMemo, useCallback } from "react";
 import { useRouter } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
 import { Sidebar } from "@/components/layout/sidebar";
@@ -19,6 +19,7 @@ import { useUIStore } from "@/stores/ui-store";
 import { useContactStore } from "@/stores/contact-store";
 import { useDeviceDetection } from "@/hooks/use-media-query";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
+import { useResizeHandle } from "@/hooks/use-resize-handle";
 import { debug } from "@/lib/debug";
 import { playNotificationSound } from "@/lib/notification-sound";
 import { cn } from "@/lib/utils";
@@ -56,6 +57,23 @@ export default function Home() {
   // Mobile/tablet responsive hooks
   const { isMobile, isTablet } = useDeviceDetection();
   const { activeView, sidebarOpen, setSidebarOpen, setActiveView, tabletListVisible, setTabletListVisible } = useUIStore();
+  const { emailListWidth, updateSetting: updateSettingsStore } = useSettingsStore();
+
+  const handleEmailListResize = useCallback((width: number) => {
+    document.documentElement.style.setProperty('--email-list-width', `${width}px`);
+  }, []);
+
+  const handleEmailListResizeEnd = useCallback((width: number) => {
+    updateSettingsStore('emailListWidth', width);
+  }, [updateSettingsStore]);
+
+  const emailListResizeHandle = useResizeHandle({
+    min: 280,
+    max: 640,
+    initial: emailListWidth,
+    onResize: handleEmailListResize,
+    onResizeEnd: handleEmailListResizeEnd,
+  });
   const {
     emails,
     mailboxes,
@@ -803,19 +821,21 @@ export default function Home() {
         {/* Main Content Area */}
         <div className="flex flex-col flex-1 min-w-0 h-full">
           <div className="flex flex-1 min-h-0">
-          {/* Email List - full width on mobile, fixed width on tablet/desktop */}
+          {/* Email List - full width on mobile, fixed (but resizable) width on tablet/desktop,
+              regardless of whether an email is currently open (matches how every other 3-pane
+              mail client behaves — the list column is a stable, user-sized pane, not something
+              that balloons to fill the screen the moment nothing happens to be selected) */}
           <div
             className={cn(
-              "flex flex-col h-full bg-background border-r border-border",
+              "relative flex flex-col h-full bg-background border-r border-border",
               // Mobile: full width, hidden when viewing email
               "max-md:flex-1 max-md:border-r-0",
               activeView !== "list" && "max-md:hidden",
-              // Tablet: full width when no email, fixed width when viewing
-              !selectedEmail ? "md:flex-1 md:border-r-0" : "md:w-80 lg:w-96 md:flex-shrink-0",
-              "md:shadow-sm",
+              "md:flex-shrink-0 md:shadow-sm",
               // Collapse list when viewing email on tablet (tabletListVisible only toggled in tablet range)
               selectedEmail && !tabletListVisible && "md:w-0 md:opacity-0 md:overflow-hidden md:border-r-0"
             )}
+            style={{ width: `var(--email-list-width, ${emailListWidth}px)` }}
           >
             {/* Mobile Header for List View */}
             <MobileHeader
@@ -885,6 +905,24 @@ export default function Home() {
                 className="flex-1"
               />
             </ErrorBoundary>
+
+            {/* Resize Handle - the list has a fixed width at all times now, so this is always active
+                (still gated on tabletListVisible: no point resizing a collapsed-to-0 list) */}
+            {tabletListVisible && (
+              <div
+                className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hidden md:block hover:bg-primary/20 active:bg-primary/30 transition-colors z-10"
+                onMouseDown={emailListResizeHandle.handleMouseDown}
+                onTouchStart={emailListResizeHandle.handleTouchStart}
+                onKeyDown={emailListResizeHandle.handleKeyDown}
+                role="separator"
+                aria-orientation="vertical"
+                aria-label="Resize email list"
+                aria-valuemin={280}
+                aria-valuemax={640}
+                aria-valuenow={emailListWidth}
+                tabIndex={0}
+              />
+            )}
           </div>
 
           {/* Email Viewer - full screen on mobile, flex on tablet/desktop */}
@@ -894,10 +932,13 @@ export default function Home() {
               // Mobile: full screen overlay when active
               "max-md:fixed max-md:inset-0 max-md:z-30",
               activeView !== "viewer" && "max-md:hidden",
-              // Tablet/Desktop: flex grow
-              "md:flex-1 md:min-w-0 md:relative",
-              // Hide viewer when no email selected (list takes full width)
-              !selectedEmail && "max-lg:hidden"
+              // Tablet/Desktop: always visible (flex grow) — shows the
+              // "no conversation selected" placeholder when nothing is open,
+              // same as every other 3-pane mail client. The list column has
+              // its own stable width regardless (see above), so this isn't
+              // fighting it for space the way it would if the list were
+              // still flex-1 in the empty state.
+              "md:flex-1 md:min-w-0 md:relative"
             )}
           >
             {/* Mobile Conversation View - shown when thread is selected on mobile */}

--- a/components/email/email-viewer.tsx
+++ b/components/email/email-viewer.tsx
@@ -56,7 +56,7 @@ import { useUIStore } from "@/stores/ui-store";
 import { useDeviceDetection } from "@/hooks/use-media-query";
 import { useAuthStore } from "@/stores/auth-store";
 import { useThemeStore } from "@/stores/theme-store";
-import { transformInlineStyles, transformColorForDarkMode, transformBgColorForDarkMode } from "@/lib/color-transform";
+import { transformInlineStyles, transformColorForDarkMode, transformBgColorForDarkMode, transformColorForLightMode, transformBgColorForLightMode } from "@/lib/color-transform";
 import { EmailIdentityBadge } from "./email-identity-badge";
 import { MobileActionBar } from "./mobile-action-bar";
 import { UnsubscribeBanner } from "./unsubscribe-banner";
@@ -592,24 +592,28 @@ export function EmailViewer({
             node.setAttribute('rel', 'noopener noreferrer');
           }
 
-          if (resolvedTheme === 'dark') {
-            if (htmlNode.style) {
-              const originalStyles = htmlNode.style.cssText;
-              const transformedStyles = transformInlineStyles(originalStyles, 'dark');
-              if (transformedStyles !== originalStyles) {
-                htmlNode.style.cssText = transformedStyles;
-              }
+          if (htmlNode.style) {
+            const originalStyles = htmlNode.style.cssText;
+            const transformedStyles = transformInlineStyles(originalStyles, resolvedTheme);
+            if (transformedStyles !== originalStyles) {
+              htmlNode.style.cssText = transformedStyles;
             }
+          }
 
-            const colorAttr = node.getAttribute('color');
-            if (colorAttr) {
-              node.setAttribute('color', transformColorForDarkMode(colorAttr));
-            }
+          const colorAttr = node.getAttribute('color');
+          if (colorAttr) {
+            node.setAttribute(
+              'color',
+              resolvedTheme === 'dark' ? transformColorForDarkMode(colorAttr) : transformColorForLightMode(colorAttr)
+            );
+          }
 
-            const bgcolorAttr = node.getAttribute('bgcolor');
-            if (bgcolorAttr) {
-              node.setAttribute('bgcolor', transformBgColorForDarkMode(bgcolorAttr));
-            }
+          const bgcolorAttr = node.getAttribute('bgcolor');
+          if (bgcolorAttr) {
+            node.setAttribute(
+              'bgcolor',
+              resolvedTheme === 'dark' ? transformBgColorForDarkMode(bgcolorAttr) : transformBgColorForLightMode(bgcolorAttr)
+            );
           }
         });
 
@@ -726,8 +730,8 @@ export function EmailViewer({
 
         {/* Loading Content Skeleton */}
         <div className="flex-1 overflow-auto bg-muted/20">
-          <div className="max-w-4xl mx-auto p-6">
-            <div className="bg-background rounded-lg shadow-sm border border-border overflow-hidden p-6 space-y-3">
+          <div className="max-w-5xl mx-auto px-5 py-6">
+            <div className="overflow-hidden px-5 py-4 space-y-3">
               <div className="h-4 bg-muted/60 rounded w-full"></div>
               <div className="h-4 bg-muted/60 rounded w-5/6"></div>
               <div className="h-4 bg-muted/60 rounded w-4/6"></div>
@@ -1519,7 +1523,7 @@ export function EmailViewer({
           (shouldShowUnsubBanner && listHeaders?.listUnsubscribe) ||
           hasCalendarInvitation) && (
           <div className="border-b border-border bg-muted/30 isolate">
-            <div className="max-w-4xl mx-auto px-6 py-1.5">
+            <div className="max-w-5xl mx-auto px-5 py-1.5">
               <div className="flex flex-col gap-3 isolate">
                 {/* External Content Controls */}
                 {hasBlockedContent && !allowExternalContent && externalContentPolicy !== 'allow' && (
@@ -1577,7 +1581,7 @@ export function EmailViewer({
           </div>
         )}
 
-        <div className="max-w-4xl mx-auto p-6">
+        <div className="max-w-5xl mx-auto px-5 py-6">
 
           {/* Attachments (excluding inline images that the body actually cites via cid:) */}
           {email.attachments && email.attachments.filter(a => !isInlineAttachment(a)).length > 0 && (
@@ -1667,10 +1671,10 @@ export function EmailViewer({
           )}
 
           {/* Email Body */}
-          <div className="bg-background rounded-lg shadow-sm border border-border overflow-x-auto">
-            <div className="email-content-wrapper p-6">
+          <div className="overflow-x-auto">
+            <div className="email-content-wrapper px-5 py-4">
               {emailContent.isHtml && emailContent.useIframe ? (
-                <SandboxedEmailFrame html={emailContent.html} className="w-full" />
+                <SandboxedEmailFrame html={emailContent.html} className="w-full" theme={resolvedTheme} />
               ) : emailContent.isHtml ? (
                 <div
                   className="email-content prose dark:prose-invert max-w-none"

--- a/components/email/sandboxed-email-frame.tsx
+++ b/components/email/sandboxed-email-frame.tsx
@@ -6,21 +6,22 @@ import { generateIframeStylesheet } from "@/lib/color-transform";
 interface SandboxedEmailFrameProps {
   html: string;
   className?: string;
+  theme?: 'light' | 'dark';
 }
 
-function wrapHtmlForIframe(sanitizedHtml: string): string {
+function wrapHtmlForIframe(sanitizedHtml: string, theme: 'light' | 'dark'): string {
   return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  ${generateIframeStylesheet()}
+  ${generateIframeStylesheet(theme)}
 </head>
 <body>${sanitizedHtml}</body>
 </html>`;
 }
 
-export function SandboxedEmailFrame({ html, className }: SandboxedEmailFrameProps) {
+export function SandboxedEmailFrame({ html, className, theme = 'light' }: SandboxedEmailFrameProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const updateHeight = useCallback(() => {
@@ -60,13 +61,13 @@ export function SandboxedEmailFrame({ html, className }: SandboxedEmailFrameProp
       iframe.removeEventListener('load', handleLoad);
       observer?.disconnect();
     };
-  }, [html, updateHeight]);
+  }, [html, theme, updateHeight]);
 
   return (
     <iframe
       ref={iframeRef}
       sandbox="allow-same-origin"
-      srcDoc={wrapHtmlForIframe(html)}
+      srcDoc={wrapHtmlForIframe(html, theme)}
       className={className}
       style={{
         width: '100%',

--- a/components/email/thread-conversation-view.tsx
+++ b/components/email/thread-conversation-view.tsx
@@ -5,7 +5,7 @@ import DOMPurify from "dompurify";
 import { Email, ThreadGroup } from "@/lib/jmap/types";
 import { hasRichFormatting, needsIframeRendering, buildEmailSanitizeConfig, collapseBlockedImageContainers, plainTextToSafeHtml } from "@/lib/email-sanitization";
 import { SandboxedEmailFrame } from "./sandboxed-email-frame";
-import { transformInlineStyles, transformColorForDarkMode, transformBgColorForDarkMode } from "@/lib/color-transform";
+import { transformInlineStyles, transformColorForDarkMode, transformBgColorForDarkMode, transformColorForLightMode, transformBgColorForLightMode } from "@/lib/color-transform";
 import { useThemeStore } from "@/stores/theme-store";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -363,24 +363,28 @@ function EmailCard({
             node.setAttribute('rel', 'noopener noreferrer');
           }
 
-          if (resolvedTheme === 'dark') {
-            if (htmlNode.style) {
-              const originalStyles = htmlNode.style.cssText;
-              const transformedStyles = transformInlineStyles(originalStyles, 'dark');
-              if (transformedStyles !== originalStyles) {
-                htmlNode.style.cssText = transformedStyles;
-              }
+          if (htmlNode.style) {
+            const originalStyles = htmlNode.style.cssText;
+            const transformedStyles = transformInlineStyles(originalStyles, resolvedTheme);
+            if (transformedStyles !== originalStyles) {
+              htmlNode.style.cssText = transformedStyles;
             }
+          }
 
-            const colorAttr = node.getAttribute('color');
-            if (colorAttr) {
-              node.setAttribute('color', transformColorForDarkMode(colorAttr));
-            }
+          const colorAttr = node.getAttribute('color');
+          if (colorAttr) {
+            node.setAttribute(
+              'color',
+              resolvedTheme === 'dark' ? transformColorForDarkMode(colorAttr) : transformColorForLightMode(colorAttr)
+            );
+          }
 
-            const bgcolorAttr = node.getAttribute('bgcolor');
-            if (bgcolorAttr) {
-              node.setAttribute('bgcolor', transformBgColorForDarkMode(bgcolorAttr));
-            }
+          const bgcolorAttr = node.getAttribute('bgcolor');
+          if (bgcolorAttr) {
+            node.setAttribute(
+              'bgcolor',
+              resolvedTheme === 'dark' ? transformBgColorForDarkMode(bgcolorAttr) : transformBgColorForLightMode(bgcolorAttr)
+            );
           }
         });
 
@@ -514,7 +518,7 @@ function EmailCard({
           {/* Email Body */}
           <div className="px-4 py-4">
             {emailContent.isHtml && emailContent.useIframe ? (
-              <SandboxedEmailFrame html={emailContent.html} className="w-full" />
+              <SandboxedEmailFrame html={emailContent.html} className="w-full" theme={resolvedTheme} />
             ) : (
               <div
                 className={cn(

--- a/hooks/use-resize-handle.ts
+++ b/hooks/use-resize-handle.ts
@@ -13,8 +13,30 @@ export function useResizeHandle({ min, max, initial, onResize, onResizeEnd }: Us
   const startX = useRef(0);
   const startWidth = useRef(initial);
   const currentWidth = useRef(initial);
+  const suspendedIframes = useRef<Array<{ el: HTMLIFrameElement; prevPointerEvents: string }>>([]);
 
   const clamp = useCallback((value: number) => Math.min(max, Math.max(min, value)), [min, max]);
+
+  // Iframes (e.g. sandboxed email content) capture mouse events in their own
+  // document, so a mouseup that happens while the cursor is over one never
+  // reaches this document's listeners and the drag appears to get "stuck".
+  // Disable pointer events on all iframes for the duration of the drag.
+  const suspendIframePointerEvents = useCallback(() => {
+    suspendedIframes.current = Array.from(document.querySelectorAll('iframe')).map((el) => ({
+      el,
+      prevPointerEvents: el.style.pointerEvents,
+    }));
+    suspendedIframes.current.forEach(({ el }) => {
+      el.style.pointerEvents = 'none';
+    });
+  }, []);
+
+  const restoreIframePointerEvents = useCallback(() => {
+    suspendedIframes.current.forEach(({ el, prevPointerEvents }) => {
+      el.style.pointerEvents = prevPointerEvents;
+    });
+    suspendedIframes.current = [];
+  }, []);
 
   useEffect(() => {
     currentWidth.current = initial;
@@ -35,6 +57,7 @@ export function useResizeHandle({ min, max, initial, onResize, onResizeEnd }: Us
       isDragging.current = false;
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
+      restoreIframePointerEvents();
       onResizeEnd(currentWidth.current);
     };
 
@@ -52,6 +75,19 @@ export function useResizeHandle({ min, max, initial, onResize, onResizeEnd }: Us
       isDragging.current = false;
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
+      restoreIframePointerEvents();
+      onResizeEnd(currentWidth.current);
+    };
+
+    // Belt-and-suspenders: if the mouse button is released outside the
+    // window entirely (or any other way that skips a plain mouseup), still
+    // end the drag and restore iframe pointer events on the next enter/blur.
+    const handleWindowBlur = () => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      restoreIframePointerEvents();
       onResizeEnd(currentWidth.current);
     };
 
@@ -59,14 +95,16 @@ export function useResizeHandle({ min, max, initial, onResize, onResizeEnd }: Us
     document.addEventListener('mouseup', handleMouseUp);
     document.addEventListener('touchmove', handleTouchMove, { passive: true });
     document.addEventListener('touchend', handleTouchEnd);
+    window.addEventListener('blur', handleWindowBlur);
 
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
       document.removeEventListener('touchmove', handleTouchMove);
       document.removeEventListener('touchend', handleTouchEnd);
+      window.removeEventListener('blur', handleWindowBlur);
     };
-  }, [clamp, onResize, onResizeEnd]);
+  }, [clamp, onResize, onResizeEnd, restoreIframePointerEvents]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -75,7 +113,8 @@ export function useResizeHandle({ min, max, initial, onResize, onResizeEnd }: Us
     startWidth.current = currentWidth.current;
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
-  }, []);
+    suspendIframePointerEvents();
+  }, [suspendIframePointerEvents]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     const touch = e.touches[0];
@@ -84,7 +123,8 @@ export function useResizeHandle({ min, max, initial, onResize, onResizeEnd }: Us
     startWidth.current = currentWidth.current;
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
-  }, []);
+    suspendIframePointerEvents();
+  }, [suspendIframePointerEvents]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     const step = 20;

--- a/lib/__tests__/color-transform.test.ts
+++ b/lib/__tests__/color-transform.test.ts
@@ -5,6 +5,8 @@ import {
   isDarkColor,
   transformColorForDarkMode,
   transformBgColorForDarkMode,
+  transformColorForLightMode,
+  transformBgColorForLightMode,
   transformInlineStyles,
 } from '../color-transform';
 
@@ -288,10 +290,143 @@ describe('transformBgColorForDarkMode', () => {
   });
 });
 
+describe('transformColorForLightMode', () => {
+  it('should darken very light colors', () => {
+    const original = '#eeeeee';
+    const transformed = transformColorForLightMode(original);
+    const originalRgb = parseColor(original)!;
+    const transformedRgb = parseColor(transformed)!;
+
+    expect(transformedRgb.r).toBeLessThan(originalRgb.r);
+    expect(transformedRgb.g).toBeLessThan(originalRgb.g);
+    expect(transformedRgb.b).toBeLessThan(originalRgb.b);
+  });
+
+  it('should darken a near-invisible light-gray body text to a readable color', () => {
+    // Representative of real transactional-email body text (e.g. #999/#ccc
+    // on a white background) that was rendering essentially invisible.
+    const transformed = transformColorForLightMode('#cccccc');
+    const rgb = parseColor(transformed)!;
+    const luminance = getLuminance(rgb.r, rgb.g, rgb.b);
+    expect(luminance).toBeLessThan(0.4);
+  });
+
+  it('should preserve hue for colored text', () => {
+    const transformed = transformColorForLightMode('#a8c7fa');
+    const rgb = parseColor(transformed)!;
+    expect(rgb.b).toBeGreaterThanOrEqual(rgb.r);
+    expect(rgb.b).toBeGreaterThan(rgb.g);
+  });
+
+  it('should preserve already dark colors', () => {
+    const darkColors = ['#111111', '#333333', 'rgb(50, 50, 50)'];
+    darkColors.forEach((color) => {
+      expect(transformColorForLightMode(color)).toBe(color);
+    });
+  });
+
+  it('should handle rgba colors with alpha', () => {
+    const original = 'rgba(220, 220, 220, 0.8)';
+    const transformed = transformColorForLightMode(original);
+    expect(transformed).toContain('rgba');
+    expect(transformed).toContain('0.8');
+  });
+
+  it('should preserve nearly transparent colors', () => {
+    const original = 'rgba(255, 255, 255, 0.05)';
+    expect(transformColorForLightMode(original)).toBe(original);
+  });
+
+  it('should handle invalid colors gracefully', () => {
+    expect(transformColorForLightMode('invalid')).toBe('invalid');
+    expect(transformColorForLightMode('inherit')).toBe('inherit');
+  });
+
+  it('should ensure minimum contrast for all light text colors', () => {
+    const lightTextColors = [
+      '#ffffff', '#eeeeee', '#dddddd', '#cccccc', '#bbbbbb', '#aaaaaa',
+    ];
+    for (const color of lightTextColors) {
+      const transformed = transformColorForLightMode(color);
+      const rgb = parseColor(transformed)!;
+      const luminance = getLuminance(rgb.r, rgb.g, rgb.b);
+      expect(luminance).toBeLessThan(0.5);
+    }
+  });
+});
+
+describe('transformBgColorForLightMode', () => {
+  it('should lighten black backgrounds', () => {
+    const transformed = transformBgColorForLightMode('#000000');
+    const rgb = parseColor(transformed)!;
+    const luminance = getLuminance(rgb.r, rgb.g, rgb.b);
+    expect(luminance).toBeGreaterThan(0.7);
+  });
+
+  it('should lighten dark gray backgrounds', () => {
+    const transformed = transformBgColorForLightMode('#1a1a2e');
+    const rgb = parseColor(transformed)!;
+    const luminance = getLuminance(rgb.r, rgb.g, rgb.b);
+    expect(luminance).toBeGreaterThan(0.7);
+  });
+
+  it('should preserve already light backgrounds', () => {
+    const lightBgs = ['#ffffff', '#f8f9fa', '#eeeeee'];
+    for (const color of lightBgs) {
+      expect(transformBgColorForLightMode(color)).toBe(color);
+    }
+  });
+
+  it('should preserve nearly transparent backgrounds', () => {
+    const original = 'rgba(0, 0, 0, 0.05)';
+    expect(transformBgColorForLightMode(original)).toBe(original);
+  });
+
+  it('should handle invalid colors gracefully', () => {
+    expect(transformBgColorForLightMode('invalid')).toBe('invalid');
+    expect(transformBgColorForLightMode('inherit')).toBe('inherit');
+  });
+
+  it('should handle rgba backgrounds', () => {
+    const transformed = transformBgColorForLightMode('rgba(0, 0, 0, 0.9)');
+    expect(transformed).toContain('rgba');
+    expect(transformed).toContain('0.9');
+    const rgb = parseColor(transformed)!;
+    expect(rgb.r).toBeGreaterThan(150);
+  });
+
+  it('should moderately lighten medium backgrounds', () => {
+    const transformed = transformBgColorForLightMode('#606060');
+    const rgb = parseColor(transformed)!;
+    const luminance = getLuminance(rgb.r, rgb.g, rgb.b);
+    expect(luminance).toBeGreaterThan(0.7);
+  });
+});
+
 describe('transformInlineStyles', () => {
-  it('should not transform styles in light mode', () => {
+  it('should not transform already-readable colors in light mode', () => {
     const original = 'color: #333333; font-size: 16px';
     expect(transformInlineStyles(original, 'light')).toBe(original);
+  });
+
+  it('should darken too-light colors in light mode', () => {
+    const original = 'color: #cccccc';
+    const transformed = transformInlineStyles(original, 'light');
+    expect(transformed).not.toBe(original);
+    expect(transformed).toContain('color:');
+    expect(transformed).toContain('rgb(');
+  });
+
+  it('should lighten too-dark background-color in light mode', () => {
+    const original = 'background-color: #111111';
+    const transformed = transformInlineStyles(original, 'light');
+    expect(transformed).not.toBe(original);
+    const colorMatch = transformed.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+    expect(colorMatch).not.toBeNull();
+    if (colorMatch) {
+      const [, r] = colorMatch.map(Number);
+      expect(r).toBeGreaterThan(150);
+    }
   });
 
   it('should transform color property in dark mode', () => {

--- a/lib/color-transform.ts
+++ b/lib/color-transform.ts
@@ -164,10 +164,62 @@ export function transformBgColorForDarkMode(colorString: string): string {
   return rgb.a !== undefined ? `rgba(${r}, ${g}, ${b}, ${rgb.a})` : `rgb(${r}, ${g}, ${b})`;
 }
 
+export function transformColorForLightMode(colorString: string): string {
+  const rgb = parseColor(colorString);
+  if (!rgb) return colorString;
+
+  if (rgb.a !== undefined && rgb.a < 0.1) {
+    return colorString;
+  }
+
+  const luminance = getLuminance(rgb.r, rgb.g, rgb.b);
+
+  // Already dark enough to read against a white/light background.
+  if (luminance <= 0.4) return colorString;
+
+  const blendFactor = 0.85 - ((1 - luminance) / 0.6) * 0.55;
+
+  // Blend toward the app's own default light-mode body text color (#1e293b),
+  // matching how transformColorForDarkMode blends toward white rather than pure black.
+  const targetR = 30, targetG = 41, targetB = 59;
+
+  const r = Math.max(0, Math.round(rgb.r + (targetR - rgb.r) * blendFactor));
+  const g = Math.max(0, Math.round(rgb.g + (targetG - rgb.g) * blendFactor));
+  const b = Math.max(0, Math.round(rgb.b + (targetB - rgb.b) * blendFactor));
+
+  return rgb.a !== undefined ? `rgba(${r}, ${g}, ${b}, ${rgb.a})` : `rgb(${r}, ${g}, ${b})`;
+}
+
+export function transformBgColorForLightMode(colorString: string): string {
+  const rgb = parseColor(colorString);
+  if (!rgb) return colorString;
+
+  if (rgb.a !== undefined && rgb.a < 0.1) {
+    return colorString;
+  }
+
+  const luminance = getLuminance(rgb.r, rgb.g, rgb.b);
+
+  // Already light enough to read text against, no correction needed.
+  if (luminance > 0.8) return colorString;
+
+  const blendFactor = Math.min(0.9, (0.8 - luminance) * 1.125);
+  const lightR = 255, lightG = 255, lightB = 255;
+
+  const r = Math.min(255, Math.round(rgb.r + (lightR - rgb.r) * blendFactor));
+  const g = Math.min(255, Math.round(rgb.g + (lightG - rgb.g) * blendFactor));
+  const b = Math.min(255, Math.round(rgb.b + (lightB - rgb.b) * blendFactor));
+
+  return rgb.a !== undefined ? `rgba(${r}, ${g}, ${b}, ${rgb.a})` : `rgb(${r}, ${g}, ${b})`;
+}
+
 export function transformInlineStyles(cssText: string, theme: 'light' | 'dark'): string {
-  if (theme !== 'dark' || !cssText) {
+  if (!cssText) {
     return cssText;
   }
+
+  const transformColor = theme === 'dark' ? transformColorForDarkMode : transformColorForLightMode;
+  const transformBgColor = theme === 'dark' ? transformBgColorForDarkMode : transformBgColorForLightMode;
 
   const styleProps = cssText.split(';').map((prop) => prop.trim()).filter(Boolean);
 
@@ -181,14 +233,14 @@ export function transformInlineStyles(cssText: string, theme: 'light' | 'dark'):
     if (property === 'color') {
       const hasImportant = value.includes('!important');
       const colorValue = value.replace('!important', '').trim();
-      const transformed = transformColorForDarkMode(colorValue);
+      const transformed = transformColor(colorValue);
       return `${property}: ${transformed}${hasImportant ? ' !important' : ''}`;
     }
 
     if (property === 'background-color') {
       const hasImportant = value.includes('!important');
       const colorValue = value.replace('!important', '').trim();
-      const transformed = transformBgColorForDarkMode(colorValue);
+      const transformed = transformBgColor(colorValue);
       return `${property}: ${transformed}${hasImportant ? ' !important' : ''}`;
     }
 
@@ -197,7 +249,7 @@ export function transformInlineStyles(cssText: string, theme: 'light' | 'dark'):
       if (colorMatch) {
         const hasImportant = value.includes('!important');
         const originalColor = colorMatch[0];
-        const transformed = transformBgColorForDarkMode(originalColor);
+        const transformed = transformBgColor(originalColor);
         const newValue = value.replace(originalColor, transformed);
         return `${property}: ${newValue.replace('!important', '').trim()}${hasImportant ? ' !important' : ''}`;
       }
@@ -206,7 +258,7 @@ export function transformInlineStyles(cssText: string, theme: 'light' | 'dark'):
     if (property === 'border-color') {
       const hasImportant = value.includes('!important');
       const colorValue = value.replace('!important', '').trim();
-      const transformed = transformColorForDarkMode(colorValue);
+      const transformed = transformColor(colorValue);
       return `${property}: ${transformed}${hasImportant ? ' !important' : ''}`;
     }
 
@@ -218,12 +270,24 @@ export function transformInlineStyles(cssText: string, theme: 'light' | 'dark'):
 
 /**
  * Generate a style block for iframe-rendered emails.
- * Uses prefers-color-scheme for native dark mode adaptation
- * instead of inline style transforms.
+ * Takes the app's own resolved theme explicitly rather than relying on
+ * prefers-color-scheme, which reflects the OS/browser preference and can
+ * disagree with an explicit in-app light/dark override.
  */
-export function generateIframeStylesheet(): string {
+export function generateIframeStylesheet(theme: 'light' | 'dark' = 'light'): string {
+  const textColor = theme === 'dark' ? '#e2e8f0' : '#1e293b';
+  const bgColor = theme === 'dark' ? '#232323' : '#ffffff';
+  const linkColor = theme === 'dark' ? '#60a5fa' : '#3b82f6';
+  const imgOpacity = theme === 'dark' ? '0.9' : '1';
+
   return `
     <style>
+      :root {
+        /* Tell the browser this content already adapts itself, so any
+           browser-level "force dark mode on websites" heuristic doesn't
+           additionally reprocess it and produce double-inverted colors. */
+        color-scheme: ${theme};
+      }
       * { box-sizing: border-box; }
       body {
         margin: 0;
@@ -234,21 +298,13 @@ export function generateIframeStylesheet(): string {
         word-wrap: break-word;
         overflow-wrap: break-word;
         overflow-x: auto;
-        color: #1e293b;
-        background: #ffffff;
+        color: ${textColor};
+        background: ${bgColor};
       }
-      img { max-width: 100%; height: auto; }
+      img { max-width: 100%; height: auto; opacity: ${imgOpacity}; }
       table { max-width: 100%; }
-      a { color: #3b82f6; }
+      a { color: ${linkColor}; }
       pre, code { white-space: pre-wrap; word-wrap: break-word; }
-      @media (prefers-color-scheme: dark) {
-        body {
-          color: #e2e8f0;
-          background: #232323;
-        }
-        a { color: #60a5fa; }
-        img { opacity: 0.9; }
-      }
     </style>
   `;
 }

--- a/stores/settings-store.ts
+++ b/stores/settings-store.ts
@@ -44,6 +44,7 @@ interface SettingsState {
 
   // Layout
   sidebarWidth: number;
+  emailListWidth: number;
 
   // Advanced
   debugMode: boolean;
@@ -97,6 +98,7 @@ const DEFAULT_SETTINGS = {
 
   // Layout
   sidebarWidth: 256,
+  emailListWidth: 384,
 
   // Advanced
   debugMode: false,
@@ -129,6 +131,11 @@ export const useSettingsStore = create<SettingsState>()(
         if (key === 'sidebarWidth') {
           applySidebarWidth(value as number);
         }
+
+        // Apply email list width to document root
+        if (key === 'emailListWidth') {
+          applyEmailListWidth(value as number);
+        }
       },
 
       resetToDefaults: () => {
@@ -137,6 +144,7 @@ export const useSettingsStore = create<SettingsState>()(
         applyListDensity(DEFAULT_SETTINGS.listDensity);
         applyAnimations(DEFAULT_SETTINGS.animationsEnabled);
         applySidebarWidth(DEFAULT_SETTINGS.sidebarWidth);
+        applyEmailListWidth(DEFAULT_SETTINGS.emailListWidth);
       },
 
       exportSettings: () => {
@@ -161,6 +169,7 @@ export const useSettingsStore = create<SettingsState>()(
           calendarNotificationsEnabled: state.calendarNotificationsEnabled,
           calendarNotificationSound: state.calendarNotificationSound,
           sidebarWidth: state.sidebarWidth,
+          emailListWidth: state.emailListWidth,
           debugMode: state.debugMode,
         };
         return JSON.stringify(settings, null, 2);
@@ -187,6 +196,7 @@ export const useSettingsStore = create<SettingsState>()(
           applyListDensity(get().listDensity);
           applyAnimations(get().animationsEnabled);
           applySidebarWidth(get().sidebarWidth);
+          applyEmailListWidth(get().emailListWidth);
 
           return true;
         } catch {
@@ -255,6 +265,12 @@ function applySidebarWidth(width: number) {
   document.documentElement.style.setProperty('--sidebar-width', `${width}px`);
 }
 
+function applyEmailListWidth(width: number) {
+  if (typeof document === 'undefined') return;
+
+  document.documentElement.style.setProperty('--email-list-width', `${width}px`);
+}
+
 function applyAnimations(enabled: boolean) {
   if (typeof document === 'undefined') return;
 
@@ -273,4 +289,5 @@ if (typeof window !== 'undefined') {
   applyListDensity(store.listDensity);
   applyAnimations(store.animationsEnabled);
   applySidebarWidth(store.sidebarWidth);
+  applyEmailListWidth(store.emailListWidth);
 }


### PR DESCRIPTION
## Summary

A handful of real issues found while running this app in production, all in the message list / email viewer area.

- **Message list column had no resize affordance.** It was hardcoded to `w-80`/`lg:w-96` once an email was open, and reverted to `flex-1` (full width) whenever nothing was selected — so the pane visibly ballooned and snapped every time you opened/closed an email or navigated away and back. Now it has a persisted, drag-resizable width (mirrors the existing sidebar-width pattern) that stays stable regardless of selection state, matching how other 3-pane mail clients behave.
- **`useResizeHandle` got stuck mid-drag** whenever the cursor passed over an iframe (e.g. the sandboxed email content right next to the list's resize handle) — the iframe captures the mouseup in its own document, so it never reaches the document-level listener the hook relies on, and the drag would keep tracking the mouse indefinitely until an unrelated click elsewhere reset it. Fixed by disabling `pointer-events` on iframes for the duration of a drag (also added a `window blur` fallback for the same class of "mouseup never fires" issue).
- **No contrast-safety pass in light mode.** Dark mode already blends colors that are too dark to read back toward white (`transformColorForDarkMode`/`transformBgColorForDarkMode`), but light mode had no equivalent — a real transactional email using pale gray body text rendered essentially invisible. Added the symmetric `transformColorForLightMode`/`transformBgColorForLightMode` and wired both directions through the existing DOMPurify hook.
- **Iframe stylesheet used `prefers-color-scheme` instead of the app's own resolved theme**, which can disagree with an explicit in-app override, and doesn't declare `color-scheme` — so a browser's own "force dark mode on websites" heuristic can additionally reprocess content this component already themes itself, producing double-processed/wrong-hue colors. `generateIframeStylesheet()` now takes the resolved theme explicitly and declares `color-scheme` accordingly.
- **Email body was a bordered/shadowed card capped at `max-w-4xl`**, regardless of how much space the viewer pane actually had. Dropped the card chrome and widened the cap to `max-w-5xl` — still bounded (most HTML email templates are authored for ~600–700px content, and stretching a template's own colored background across a much wider container looks broken), just less cramped than before.

## Test plan

- `npx vitest run` — 862/862 passing (17 new tests added for the light-mode transform functions, mirroring existing dark-mode coverage).
- `npx next build --webpack` — builds clean, TypeScript check passes.
- Manually verified in a real deployment: list resize (including dragging across the open email's iframe), light-mode contrast against a real low-contrast transactional email, dark-mode rendering unaffected, and list width staying stable across navigation/selection changes.
